### PR TITLE
fix: Config path always opening even if config JSON is specified.

### DIFF
--- a/src/cloaiservice/config.py
+++ b/src/cloaiservice/config.py
@@ -108,13 +108,15 @@ def get_config() -> Config:
     """
     # First try loading from CONFIG_JSON environment variable
     config_path = pathlib.Path(environ.get("CONFIG_PATH", "config.json"))
-    try:
-        config_json = environ.get("CONFIG_JSON", config_path.read_text())
-    except FileNotFoundError:
-        raise fastapi.HTTPException(
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
-            "Config file not found and CONFIG_JSON environment variable not set.",
-        )
+    config_json = environ.get("CONFIG_JSON")
+    if not config_json:
+        try:
+           config_json = config_path.read_text()
+        except FileNotFoundError:
+            raise fastapi.HTTPException(
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                "Config file not found and CONFIG_JSON environment variable not set.",
+            )
 
     try:
         client_config = ClientConfig.model_validate_json(config_json)

--- a/src/cloaiservice/config.py
+++ b/src/cloaiservice/config.py
@@ -111,8 +111,8 @@ def get_config() -> Config:
     config_json = environ.get("CONFIG_JSON")
     if not config_json:
         try:
-           config_json = config_path.read_text()
-        except FileNotFoundError:
+            config_json = config_path.read_text()
+        except (FileNotFoundError, IsADirectoryError):
             raise fastapi.HTTPException(
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
                 "Config file not found and CONFIG_JSON environment variable not set.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,65 @@
+import pathlib
+
+import pytest
+
+from cloaiservice import config
+
+import os
+
+import functools
+
+@pytest.fixture
+def config_json() -> str:
+    return """
+    {
+        "clients": {
+            "test-model": { 
+                "type": "bedrock-anthropic", 
+                "model": "anthropic.claude-3-5-sonnet-20241022-v2:0", 
+                "aws_access_key": "01234567890123456789", 
+                "aws_secret_key": "0123456789012345678901234567890123456789", 
+                "region": "us-west-2"
+            }
+        }
+    }
+    """
+
+def reset_env_variables(*env_vars):
+    """Wrapper that saves specified environment variables and resets them after the test."""
+    def decorator(function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            cache = {var: os.environ.get(var) for var in env_vars if os.environ.get(var)}
+            try:
+                function(*args, **kwargs)
+            finally:
+                for key, value in cache.items():
+                    os.environ[key] = value
+        return wrapper
+    return decorator
+
+
+@reset_env_variables("CONFIG_PATH", "CONFIG_JSON")
+def test_get_config_environment(config_json:str) -> None:
+    """Get CONFIG_JSON from environment."""
+    os.environ["CONFIG_PATH"] = ""
+    os.environ["CONFIG_JSON"] = config_json
+
+    result = config.get_config()
+
+    assert len(result.clients) == 1
+    assert result.clients['test-model'].client.model == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+
+@reset_env_variables("CONFIG_PATH", "CONFIG_JSON")
+def test_get_config_file(tmp_path: pathlib.Path, config_json:str ) -> None:
+    """Get CONFIG_JSON from file."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(config_json)
+    os.environ["CONFIG_PATH"] = str(config_file)
+    os.environ["CONFIG_JSON"] = ""
+
+    result = config.get_config()
+
+    assert len(result.clients) == 1
+    assert result.clients['test-model'].client.model == "anthropic.claude-3-5-sonnet-20241022-v2:0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,7 @@ def reset_env_variables(*env_vars):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             cache = {
-                var: os.environ.get(var) for var in env_vars if os.environ.get(var)
+                var: os.environ.get(var, "") for var in env_vars
             }
             try:
                 function(*args, **kwargs)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,23 +1,26 @@
+"""Unit tests for the config module."""
+
+import functools
+import os
 import pathlib
+from typing import Any
 
 import fastapi
-from fastapi import status
 import pytest
+from fastapi import status
 
 from cloaiservice import config
 
-import os
-
-import functools
-
 
 @pytest.fixture(autouse=True, scope="function")
-def reset_cache():
+def reset_cache() -> None:
+    """Resets the get_config cache on every test."""
     config.get_config.cache_clear()
 
 
 @pytest.fixture
 def config_json() -> str:
+    """A JSON configuration used for the tests."""
     return """
     {
         "clients": {
@@ -33,15 +36,14 @@ def config_json() -> str:
     """
 
 
-def reset_env_variables(*env_vars):
-    """Wrapper that saves specified environment variables and resets them after the test."""
+def reset_env_variables(*env_vars: str) -> None:
+    """Saves environment variables and resets them after the test."""
+    from typing import Callable
 
-    def decorator(function):
+    def decorator(function: Callable) -> Callable:
         @functools.wraps(function)
-        def wrapper(*args, **kwargs):
-            cache = {
-                var: os.environ.get(var, "") for var in env_vars
-            }
+        def wrapper(*args: Any, **kwargs: Any) -> Callable:  # noqa: ANN401
+            cache = {var: os.environ.get(var, "") for var in env_vars}
             try:
                 function(*args, **kwargs)
             finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,12 +3,12 @@
 import functools
 import os
 import pathlib
-from typing import Any
+from typing import Any, Callable
 
 import fastapi
 import pytest
 from fastapi import status
-from typing import Callable
+
 from cloaiservice import config
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ from typing import Any
 import fastapi
 import pytest
 from fastapi import status
-
+from typing import Callable
 from cloaiservice import config
 
 
@@ -36,13 +36,12 @@ def config_json() -> str:
     """
 
 
-def reset_env_variables(*env_vars: str) -> None:
+def reset_env_variables(*env_vars: str) -> Callable:
     """Saves environment variables and resets them after the test."""
-    from typing import Callable
 
     def decorator(function: Callable) -> Callable:
         @functools.wraps(function)
-        def wrapper(*args: Any, **kwargs: Any) -> Callable:  # noqa: ANN401
+        def wrapper(*args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             cache = {var: os.environ.get(var, "") for var in env_vars}
             try:
                 function(*args, **kwargs)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,9 +10,11 @@ import os
 
 import functools
 
+
 @pytest.fixture(autouse=True, scope="function")
 def reset_cache():
     config.get_config.cache_clear()
+
 
 @pytest.fixture
 def config_json() -> str:
@@ -30,23 +32,29 @@ def config_json() -> str:
     }
     """
 
+
 def reset_env_variables(*env_vars):
     """Wrapper that saves specified environment variables and resets them after the test."""
+
     def decorator(function):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            cache = {var: os.environ.get(var) for var in env_vars if os.environ.get(var)}
+            cache = {
+                var: os.environ.get(var) for var in env_vars if os.environ.get(var)
+            }
             try:
                 function(*args, **kwargs)
             finally:
                 for key, value in cache.items():
                     os.environ[key] = value
+
         return wrapper
+
     return decorator
 
 
 @reset_env_variables("CONFIG_PATH", "CONFIG_JSON")
-def test_get_config_environment(config_json:str) -> None:
+def test_get_config_environment(config_json: str) -> None:
     """Get CONFIG_JSON from environment."""
     os.environ["CONFIG_PATH"] = ""
     os.environ["CONFIG_JSON"] = config_json
@@ -54,11 +62,14 @@ def test_get_config_environment(config_json:str) -> None:
     result = config.get_config()
 
     assert len(result.clients) == 1
-    assert result.clients['test-model'].client.model == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    assert (
+        result.clients["test-model"].client.model
+        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
 
 
 @reset_env_variables("CONFIG_PATH", "CONFIG_JSON")
-def test_get_config_file(tmp_path: pathlib.Path, config_json:str ) -> None:
+def test_get_config_file(tmp_path: pathlib.Path, config_json: str) -> None:
     """Get CONFIG_JSON from file."""
     config_file = tmp_path / "config.json"
     config_file.write_text(config_json)
@@ -68,7 +79,11 @@ def test_get_config_file(tmp_path: pathlib.Path, config_json:str ) -> None:
     result = config.get_config()
 
     assert len(result.clients) == 1
-    assert result.clients['test-model'].client.model == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    assert (
+        result.clients["test-model"].client.model
+        == "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
 
 @reset_env_variables("CONFIG_PATH", "CONFIG_JSON")
 def test_get_config_not_specified() -> None:


### PR DESCRIPTION
I introduced a bug in the last PR where the CONFIG_PATH file is always opened, even if CONFIG_JSON is specified. This PR resolves that and also introduces some unit tests to validate this particular piece of code. 