### PR TITLE
feat: Improve descriptions of config errors

### DIFF
--- a/src/cloaiservice/config.py
+++ b/src/cloaiservice/config.py
@@ -1,9 +1,10 @@
 """App configuration."""
 
+import json
 import pathlib
 from functools import lru_cache
 from os import environ
-from typing import Literal
+from typing import Any, Literal
 
 import cloai
 import fastapi
@@ -79,22 +80,71 @@ class AzureConfig(BaseModel):
         )
 
 
-class ClientConfig(BaseModel):
-    """Configuration for all clients."""
+def create_clients(
+    config: dict[str, dict[str, Any]],
+) -> dict[str, cloai.LargeLanguageModel]:
+    """Creates the LLM clients.
 
-    clients: dict[str, BedrockAnthropicConfig | OpenAIConfig | AzureConfig]
+    This function will run for all clients, even when one fails, so that
+    all errors in the config can be returned to the user.
 
-    def create_clients(self) -> dict[str, cloai.LargeLanguageModel]:
-        """Create all client instances."""
-        return {name: config.create_client() for name, config in self.clients.items()}
+    Args:
+        config: The JSON formatted configurations.
+
+    Returns:
+        A dictionary of LLM clients.
+
+    Raises:
+        500: For malformed configurations.
+    """
+    clients: dict[str, cloai.LargeLanguageModel] = {}
+    errors = []
+
+    type_constructors = {
+        "azure": AzureConfig,
+        "bedrock-anthropic": BedrockAnthropicConfig,
+        "openai": OpenAIConfig,
+    }
+
+    for name, args in config["clients"].items():
+        if "type" not in args:
+            errors.append(f"Client {name} is missing a 'type' property.")
+            continue
+
+        if args["type"] not in type_constructors:
+            errors.append(
+                (
+                    f"Unknown client type: {args['type']}. "
+                    f"Valid types: {type_constructors.keys()}"
+                )
+            )
+            continue
+
+        try:
+            clients[name] = type_constructors[args["type"]](**args).create_client()
+        except pydantic.ValidationError as exc_info:
+            # Report only the type and the location, as further contents may contain
+            # secrets.
+            validation_errors = [
+                f"Error type: {error['type']}, Location: {error['loc']}"
+                for error in exc_info.errors()
+            ]
+            errors.append(
+                f"Error validating client {name}: " + " ".join(validation_errors)
+            )
+
+    if errors:
+        raise fastapi.HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="; ".join(errors)
+        )
+
+    return clients
 
 
-class Config:
+class Config(pydantic.BaseModel):
     """Service configuration."""
 
-    def __init__(self, clients: dict[str, cloai.LargeLanguageModel]) -> None:
-        """Initialize service configuration."""
-        self.clients = clients
+    clients: dict[str, cloai.LargeLanguageModel]
 
 
 @lru_cache()
@@ -118,10 +168,5 @@ def get_config() -> Config:
                 "Config file not found and CONFIG_JSON environment variable not set.",
             )
 
-    try:
-        client_config = ClientConfig.model_validate_json(config_json)
-    except pydantic.ValidationError:
-        raise fastapi.HTTPException(
-            status.HTTP_500_INTERNAL_SERVER_ERROR, "Invalid model JSON configuration."
-        )
-    return Config(clients=client_config.create_clients())
+    clients = create_clients(json.loads(config_json))
+    return Config(clients=clients)

--- a/src/cloaiservice/main.py
+++ b/src/cloaiservice/main.py
@@ -2,12 +2,14 @@
 
 from fastapi import APIRouter, FastAPI
 
+from cloaiservice import config
 from cloaiservice.routes import clients, health, llm
 
 app = FastAPI(
     title="cloai API Service",
     description="API service for interacting with various LLM providers",
     version="0.1.0",
+    on_startup=[config.get_config],  # Ensure that the config is correct on startup
 )
 
 version_router = APIRouter(prefix="/v1")


### PR DESCRIPTION
The current architecture of setting up the config is very short & sweet, but produces no interpretable feedback in case of error. I'm running into this with the e2e testing config, and I have no idea how to debug it. 

I've revamped the responses for faulty configs to provide clear errors to the caller in terms of what is wrong. I've also made the app run (and cache) `get_config` on startup, the container will crash in case of error. Since faulty config leads to 500 responses on everything except the `health` endpoint, this seems like appropriate behavior. 